### PR TITLE
fix: vod page user-interface

### DIFF
--- a/src/app/(components)/vods.tsx
+++ b/src/app/(components)/vods.tsx
@@ -77,7 +77,7 @@ export const VODs = async (props: { username: string }) => {
   const data = (response as TwitchVodRequest).data;
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-4 overflow-y-auto p-4 w-full">
+    <div className="flex flex-wrap justify-center gap-4 self-center max-w-7xl">
       {data.length === 0 ? (
         <VodEmptyState />
       ) : (

--- a/src/app/(components)/vods.tsx
+++ b/src/app/(components)/vods.tsx
@@ -77,7 +77,7 @@ export const VODs = async (props: { username: string }) => {
   const data = (response as TwitchVodRequest).data;
 
   return (
-    <div className="flex flex-1 flex-wrap items-center justify-center gap-4 overflow-y-auto p-4">
+    <div className="flex flex-wrap items-center justify-center gap-4 overflow-y-auto p-4">
       {data.length === 0 ? (
         <VodEmptyState />
       ) : (

--- a/src/app/(components)/vods.tsx
+++ b/src/app/(components)/vods.tsx
@@ -77,7 +77,7 @@ export const VODs = async (props: { username: string }) => {
   const data = (response as TwitchVodRequest).data;
 
   return (
-    <div className="flex flex-wrap justify-center gap-4 self-center max-w-7xl">
+    <div className="flex flex-wrap justify-center gap-4 self-center max-w-7xl overflow-y-auto max-h-[80vh]">
       {data.length === 0 ? (
         <VodEmptyState />
       ) : (

--- a/src/app/(components)/vods.tsx
+++ b/src/app/(components)/vods.tsx
@@ -77,7 +77,7 @@ export const VODs = async (props: { username: string }) => {
   const data = (response as TwitchVodRequest).data;
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-4 overflow-y-auto p-4">
+    <div className="flex flex-wrap items-center justify-center gap-4 overflow-y-auto p-4 w-full">
       {data.length === 0 ? (
         <VodEmptyState />
       ) : (

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -10,7 +10,7 @@ export const revalidate = 0;
 
 export default async function Home({ params }: { params: { slug: string } }) {
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className="flex flex-1 grow mx-auto items-center">
       <Suspense fallback={<LoadingPage />}>
         {/* @ts-expect-error Server Component */}
         <VODs username={params.slug} />


### PR DESCRIPTION
Attempts to resolves issue #32.

Minor fix for the VOD listings displayed in `/src/app/(components)/vods.tsx`, now ensuring that no VODs are missing/clipped from the page when displayed.

- Removes overflowing on the y-axis
- Improves vod item and vod container centering

As I only have one Twitch VOD, I duplicated the element *n* times to test responsiveness.

<details>
  <summary>Mobile & Desktop Screenshots</summary>
  
  ![localhost_3000_toxocious](https://user-images.githubusercontent.com/13388656/230230824-8e90ffd6-769c-4ffa-8d13-ae70a75a8f92.png)
  ![localhost_3000_toxocious (1)](https://user-images.githubusercontent.com/13388656/230230965-9f90b7e0-6b2d-449f-88d8-46d01d0dc859.png)
  ![localhost_3000_toxocious (2)](https://user-images.githubusercontent.com/13388656/230230874-af68ae32-256c-466d-9c8b-2a181e823f47.png)
  ![localhost_3000_toxocious (3)](https://user-images.githubusercontent.com/13388656/230230885-e92f370d-033b-417d-a27e-686879504e07.png)
</details>
