### PR TITLE
SWC Minifier is enabled by default as of v13.0.0

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,6 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  swcMinify: true,
 };
 
 const withMdx = require("@next/mdx")()(nextConfig);


### PR DESCRIPTION
Next.js' swc compiler is used for minification by default since v13. 
Default behaviour is `swcMinify: true`

https://nextjs.org/docs/advanced-features/compiler#minification