### PR TITLE
add some minimal wrapping to header in player

### DIFF
--- a/src/app/(core)/v/[slug]/player.tsx
+++ b/src/app/(core)/v/[slug]/player.tsx
@@ -144,7 +144,7 @@ export const VodPlayer = (props: { id: string; vod: VOD }) => {
 
       {/* Timestamps */}
       <Card className="row-span-2 flex h-full min-h-0 flex-col gap-2 p-4 shadow-md sm:col-span-1 sm:row-span-1">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-1.5 ">
           <h1 className="flex items-center gap-1.5 text-lg font-semibold ">
             <span>Timestamps</span>
           </h1>


### PR DESCRIPTION
i don't actually have my dev env set up so i can't test thoroughly but this should be good enough based on fucking around in my dev tools. theo complained on stream so figured i'd make a quick PR

note: i tried making the button container have a width of 100% so when it wraps, the buttons take up the full width of the header instead of just kinda floating over on the left. will take some more investigation but this is an easy patch for now lol