### PR TITLE
Remove static sitemap, generate 'dynamic' sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://marker.ping.gg</loc>
-    <lastmod>2023-04-06</lastmod>
-  </url>
-</urlset>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,10 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://marker.ping.gg",
+      lastModified: new Date(),
+    },
+  ];
+}


### PR DESCRIPTION
[Current sitemap.xml](https://github.com/pingdotgg/markerthing/blob/e06da47b8ef75998dd8d172d0ffe0b314e03eeda/public/sitemap.xml) has static `<lastmod>2023-04-06</lastmod>`. This will have to be changed manually or will always stay as the same outdated value. 

Replaced it with a generated Sitemap ([see NextJS docs](https://beta.nextjs.org/docs/api-reference/metadata#generate-a-sitemap)).

Old output: 
```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://marker.ping.gg</loc>
    <lastmod>2023-04-06</lastmod>
  </url>
</urlset>
```

New output: 
```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://marker.ping.gg</loc>
    <lastmod>2023-04-06T15:02:24.021Z</lastmod>
  </url>
</urlset>
```

However, `<lastmod/>` will always be up to date with new approach, because it is using `new Date()` on build. 